### PR TITLE
Fix noun context propagation

### DIFF
--- a/src/constituent/Clause.js
+++ b/src/constituent/Clause.js
@@ -64,13 +64,12 @@ class Clause extends Constituent {
             this.data.subject
         ], context, {hasFirst: false, hasLast: false});
 
-        flatSubject
-            .filter(ii => Noun.isNoun(ii))
-            .forEach((ii: Constituent|string) => {
-                context = context
-                    .set('number', ii.data.number)
-                    .set('person', ii.data.person);
-            });
+        var noun = this.getIn(['subject','noun']);
+        if(noun) {
+            context = context
+                .set('number', noun.get('number'))
+                .set('person', noun.get('person'));
+        }
 
         const flatPredicate: List<Constituent|string> = this._flattenChildren([
             this.data.verb,

--- a/src/constituent/Constituent.js
+++ b/src/constituent/Constituent.js
@@ -190,8 +190,24 @@ class Constituent {
             .join("");
     }
 
-    get(key: string): any {
-        return this.data.get(key);
+    has(key: string): any {
+        return this.data.has(key);
+    }
+
+    get(key: string, notSetValue: *): any {
+        return this.data.get(key, notSetValue);
+    }
+
+    getIn(keyPath: string[], notSetValue: * = undefined): any {
+        var item = this;
+        for(var ii in keyPath) {
+            var key = keyPath[ii];
+            if(!item || !item.has(key)) {
+                return notSetValue;
+            }
+            item = item.get(key);
+        }
+        return item;
     }
 
     before(item: Array<Constituent|string>|List<Constituent|string>|Constituent|string): Constituent {


### PR DESCRIPTION
Fixed bug where nouns in modifiers on noun phrases in the subject of a clause were inadvertently selected to pass number ("singular" or "plural") and person ("first", "second", "third") attributes by context to the clause's verb, instead of using the actual noun in the clause's subject position. So now auxiliary verbs on verb phrases in those clauses look right.

e.g.
- "The dog has been jumping" - all good before and after this PR
- "The dogs have been jumping" - all good before and after this PR
- "The dog in the house has been jumping" - all good before and after this PR
- "The dogs in the house **has been** jumping" - oh no! "house" is singular so "has been" is assuming it applies to a singular noun. It should be receiving it's pluralisation context from "dog" / "dogs", not "house".

Also happened with person.

e.g.
- He, in his infinite wisdom, is always mowing the lawn in the rain. - all good
- I, in my infinite wisdom, **is** always mowing the lawn in the rain. - oh no!

Also added a `has()` and a `getIn` on all constituents.