### PR TITLE
Pass config, export arbitrarystring, add numberformatter

### DIFF
--- a/example/src/components/Page.jsx
+++ b/example/src/components/Page.jsx
@@ -12,7 +12,10 @@ const {
     V,
     VP,
     Series
-} = Constituent(Lexicon);
+} = Constituent({
+    lexicon: Lexicon,
+    numberRenderer: ii => `${ii}`
+});
 
 
 
@@ -46,7 +49,7 @@ export default () => {
 
     sentences.push(() => {
         return Sentence(
-            NP("fire")
+            NP("fire").setMeta("ppp", "ooo").adj("big")
         );
     });
 
@@ -84,6 +87,25 @@ export default () => {
         );
     });
 
+    sentences.push('<h2>Number noun tests</h2>');
+
+    sentences.push(() => {
+        return Sentence(
+            Clause(
+                NP("age").possessor("my"),
+                VP("is", NP("twelve"))
+            )
+        );
+    });
+
+    sentences.push(() => {
+        return Sentence(
+            Clause(
+                NP("age").possessor("my"),
+                VP("is", NP(123456))
+            )
+        );
+    });
 
     sentences.push('<h2>Verb tests</h2>');
 

--- a/src/constituent/Adjective.js
+++ b/src/constituent/Adjective.js
@@ -25,12 +25,15 @@ class Adjective extends Constituent {
     }
 }
 
-const AdjectiveFactory = (adjective: Adjective|string): Adjective => {
+const AdjectiveFactory = (config: Object) => (adjective: Adjective|string): Adjective => {
     CheckType(adjective, ["Adjective", "string"]);
     if(Adjective.isAdjective(adjective)) {
         return adjective;
     }
-    return new Adjective(AdjectiveRecord({adjective}));
+    return new Adjective(
+        AdjectiveRecord({adjective}),
+        config
+    );
 };
 
 export {

--- a/src/constituent/AdjectivePhrase.js
+++ b/src/constituent/AdjectivePhrase.js
@@ -1,5 +1,5 @@
 import {List, Map} from 'immutable';
-import {Constituent, ConstituentRecordFactory, } from './Constituent';
+import {Constituent, ConstituentRecordFactory, ArbitraryString} from './Constituent';
 import {Adjective, AdjectiveFactory} from './Adjective';
 import {Series} from './Series';
 
@@ -39,13 +39,18 @@ class AdjectivePhrase extends Constituent {
     }
 }
 
-const AdjectivePhraseFactory = (adjective: AdjectivePhrase|Adjective|string): AdjectivePhrase => {
+const AdjectivePhraseFactory = (config: Object) => (adjective: AdjectivePhrase|Adjective|string): AdjectivePhrase => {
     if(AdjectivePhrase.isAdjectivePhrase(adjective)) {
         return adjective;
     }
-    return new AdjectivePhrase(AdjectivePhraseRecord({
-        adjective: Series.isSeries(adjective) ? adjective : AdjectiveFactory(adjective)
-    }));
+    return new AdjectivePhrase(
+        AdjectivePhraseRecord({
+            adjective: Series.isSeries(adjective) || ArbitraryString.isArbitraryString(adjective)
+                ? adjective
+                : AdjectiveFactory(config)(adjective)
+        }),
+        config
+    );
 };
 
 export {

--- a/src/constituent/Adverb.js
+++ b/src/constituent/Adverb.js
@@ -25,12 +25,15 @@ class Adverb extends Constituent {
     }
 }
 
-const AdverbFactory = (adverb: Adverb|string): Adverb => {
+const AdverbFactory = (config: Object) => (adverb: Adverb|string): Adverb => {
     CheckType(adverb, ["Adverb", "string"]);
     if(Adverb.isAdverb(adverb)) {
         return adverb;
     }
-    return new Adverb(AdverbRecord({adverb}));
+    return new Adverb(
+        AdverbRecord({adverb}),
+        config
+    );
 };
 
 export {

--- a/src/constituent/AdverbPhrase.js
+++ b/src/constituent/AdverbPhrase.js
@@ -1,5 +1,5 @@
 import {List} from 'immutable';
-import {Constituent, ConstituentRecordFactory} from './Constituent';
+import {Constituent, ConstituentRecordFactory, ArbitraryString} from './Constituent';
 import {Adverb, AdverbFactory} from './Adverb';
 import {Series} from './Series';
 
@@ -29,13 +29,18 @@ class AdverbPhrase extends Constituent {
     }
 }
 
-const AdverbPhraseFactory = (adverb: AdverbPhrase|Adverb|string): AdverbPhrase => {
+const AdverbPhraseFactory = (config: Object) => (adverb: AdverbPhrase|Adverb|string): AdverbPhrase => {
     if(AdverbPhrase.isAdverbPhrase(adverb)) {
         return adverb;
     }
-    return new AdverbPhrase(AdverbPhraseRecord({
-        adverb: Series.isSeries(adverb) ? adverb : AdverbFactory(adverb)
-    }));
+    return new AdverbPhrase(
+        AdverbPhraseRecord({
+            adverb: Series.isSeries(adverb) || ArbitraryString.isArbitraryString(adverb)
+                ? adverb
+                : AdverbFactory(config)(adverb)
+        }),
+        config
+    );
 };
 
 export {

--- a/src/constituent/Clause.js
+++ b/src/constituent/Clause.js
@@ -1,15 +1,13 @@
 import {List, Map} from 'immutable';
 import {Constituent, ConstituentRecordFactory} from './Constituent';
 import {CheckType, CheckEnum} from '../decls/TypeErrors';
-import {Adjective} from './Adjective';
 import {AdjectivePhrase} from './AdjectivePhrase';
 import {Adverb, AdverbFactory} from './Adverb';
 import {AdverbPhrase} from './AdverbPhrase';
 import {Determiner, DeterminerFactory} from './Determiner';
-import {Noun} from './Noun';
 import {NounPhrase} from './NounPhrase';
 import {Pronoun, PronounFactory} from './Pronoun';
-import {Verb, TENSE_ENUM, ASPECT_ENUM} from './Verb';
+import {TENSE_ENUM, ASPECT_ENUM} from './Verb';
 import {VerbPhrase} from './VerbPhrase';
 
 const ClauseRecord = ConstituentRecordFactory({
@@ -93,7 +91,7 @@ class Clause extends Constituent {
         CheckType(whAdverb, ['Adverb', 'string']);
         return this.clone({
             data: this.data
-                .set('whAdverb', AdverbFactory(whAdverb))
+                .set('whAdverb', AdverbFactory(this.config)(whAdverb))
                 .set('whDeterminer', '')
                 .set('whPronoun', '')
         });
@@ -104,7 +102,7 @@ class Clause extends Constituent {
         return this.clone({
             data: this.data
                 .set('whAdverb', '')
-                .set('whDeterminer', DeterminerFactory(whDeterminer))
+                .set('whDeterminer', DeterminerFactory(this.config)(whDeterminer))
                 .set('whPronoun', '')
         });
     }
@@ -115,7 +113,7 @@ class Clause extends Constituent {
             data: this.data
                 .set('whDeterminer', '')
                 .set('whAdverb', '')
-                .set('whPronoun', PronounFactory(whPronoun))
+                .set('whPronoun', PronounFactory(this.config)(whPronoun))
         });
     }
 
@@ -167,7 +165,7 @@ class Clause extends Constituent {
     }
 }
 
-const ClauseFactory = (
+const ClauseFactory = (config: Object) => (
     subjectOrClause: Clause|NounPhrase|AdverbPhrase|Determiner|null,
     verb: VerbPhrase|string,
     object: ?Clause|NounPhrase|AdjectivePhrase
@@ -183,34 +181,46 @@ const ClauseFactory = (
     object = object || null;
 
     if(AdverbPhrase.isAdverbPhrase(subjectOrClause)) {
-        return new Clause(ClauseRecord({
-            whAdverb: subjectOrClause,
-            verb,
-            object
-        }));
+        return new Clause(
+            ClauseRecord({
+                whAdverb: subjectOrClause,
+                verb,
+                object
+            }),
+            config
+        );
     }
 
     if(Determiner.isDeterminer(subjectOrClause)) {
-        return new Clause(ClauseRecord({
-            whDeterminer: subjectOrClause,
-            verb,
-            object
-        }));
+        return new Clause(
+            ClauseRecord({
+                whDeterminer: subjectOrClause,
+                verb,
+                object
+            }),
+            config
+        );
     }
 
     if(Pronoun.isPronoun(subjectOrClause)) {
-        return new Clause(ClauseRecord({
-            whPronoun: subjectOrClause,
-            verb,
-            object
-        }));
+        return new Clause(
+            ClauseRecord({
+                whPronoun: subjectOrClause,
+                verb,
+                object
+            }),
+            config
+        );
     }
 
-    return new Clause(ClauseRecord({
-        subject: subjectOrClause,
-        verb,
-        object
-    }));
+    return new Clause(
+        ClauseRecord({
+            subject: subjectOrClause,
+            verb,
+            object
+        }),
+        config
+    );
 };
 
 

--- a/src/constituent/Conjunction.js
+++ b/src/constituent/Conjunction.js
@@ -26,12 +26,15 @@ class Conjunction extends Constituent {
 
 }
 
-const ConjunctionFactory = (conjunction: Conjunction|string): Conjunction => {
+const ConjunctionFactory = (config: Object) => (conjunction: Conjunction|string): Conjunction => {
     CheckType(conjunction, ["Conjunction", "string"]);
     if(Conjunction.isConjunction(conjunction)) {
         return conjunction;
     }
-    return new Conjunction(ConjunctionRecord({conjunction}));
+    return new Conjunction(
+        ConjunctionRecord({conjunction}),
+        config
+    );
 };
 
 export {

--- a/src/constituent/Determiner.js
+++ b/src/constituent/Determiner.js
@@ -25,14 +25,11 @@ class Determiner extends Constituent {
     }
 
     _flattenSelf(context: Map<string, any>): List<Constituent|string> {
-        const quantity: number|string = this.data.quantity != null
-            ? `${this.data.quantity}`
-            : null;
 
         return this._flattenChildren([
             this.data.possessor,
             this.data.determiner,
-            quantity
+            this._renderNumberString(this.data.quantity)
         ], context);
     }
 
@@ -68,7 +65,7 @@ class Determiner extends Constituent {
 
     possessor(possessor: NounPhrase|string, suffix: string = null): Determiner {
         CheckType(possessor, ["NounPhrase", "string"]);
-        possessor = NounPhraseFactory(possessor);
+        possessor = NounPhraseFactory(this.config)(possessor);
         if(suffix) {
             possessor = possessor.after(suffix);
         }
@@ -79,14 +76,17 @@ class Determiner extends Constituent {
     }
 }
 
-const DeterminerFactory = (determiner: Determiner|string): Determiner => {
+const DeterminerFactory = (config: Object) => (determiner: Determiner|string): Determiner => {
     CheckType(determiner, [Determiner, "string", "undefined", "null"]);
     if(Determiner.isDeterminer(determiner)) {
         return determiner;
     }
-    return new Determiner(DeterminerRecord({
-        determiner: determiner || ""
-    }));
+    return new Determiner(
+        DeterminerRecord({
+            determiner: determiner || ""
+        }),
+        config
+    );
 };
 
 export {

--- a/src/constituent/Noun.js
+++ b/src/constituent/Noun.js
@@ -56,6 +56,8 @@ class Noun extends Constituent {
             person
         } = this.data;
 
+        noun = this._renderNumberString(noun);
+
         if(person == "first") {
             return number == "singular" ? "I" : "we";
         }
@@ -64,6 +66,7 @@ class Noun extends Constituent {
         }
         if(number == "plural") {
             noun = plural || `${noun}s`;
+            // TODO use lexicon for pluralization rules https://github.com/blueflag/phraser/issues/8
         }
         return noun;
     }
@@ -130,14 +133,17 @@ class Noun extends Constituent {
 
 }
 
-const NounFactory = (noun: Noun|string|number): Noun => {
+const NounFactory = (config: Object) => (noun: Noun|string|number): Noun => {
     CheckType(noun, [Noun, "string", "number"]);
     if(Noun.isNoun(noun)) {
         return noun;
     }
-    return new Noun(NounRecord({
-        noun: `${noun}`
-    }));
+    return new Noun(
+        NounRecord({
+            noun
+        }),
+        config
+    );
 };
 
 export {

--- a/src/constituent/Paragraph.js
+++ b/src/constituent/Paragraph.js
@@ -28,10 +28,13 @@ class Paragraph extends Constituent {
 
 }
 
-const ParagraphFactory = (...sentences: Sentence): Paragraph => {
-    return new Paragraph(ParagraphRecord({
-        sentences: List(sentences)
-    }));
+const ParagraphFactory = (config: Object) => (...sentences: Sentence): Paragraph => {
+    return new Paragraph(
+        ParagraphRecord({
+            sentences: List(sentences)
+        }),
+        config
+    );
 };
 
 export {

--- a/src/constituent/Preposition.js
+++ b/src/constituent/Preposition.js
@@ -26,12 +26,15 @@ class Preposition extends Constituent {
 
 }
 
-const PrepositionFactory = (preposition: Preposition|string): Preposition => {
+const PrepositionFactory = (config: Object) => (preposition: Preposition|string): Preposition => {
     CheckType(preposition, ["Preposition", "string"]);
     if(Preposition.isPreposition(preposition)) {
         return preposition;
     }
-    return new Preposition(PrepositionRecord({preposition}));
+    return new Preposition(
+        PrepositionRecord({preposition}),
+        config
+    );
 };
 
 export {

--- a/src/constituent/PrepositionPhrase.js
+++ b/src/constituent/PrepositionPhrase.js
@@ -31,7 +31,7 @@ class PrepositionPhrase extends Constituent {
     }
 }
 
-const PrepositionPhraseFactory = (
+const PrepositionPhraseFactory = (config: Object) => (
     prepositionOrPhrase: PrepositionPhrase|Preposition|string,
     object: NounPhrase|Noun|string
 ): PrepositionPhrase => {
@@ -40,10 +40,13 @@ const PrepositionPhraseFactory = (
         return prepositionOrPhrase;
     }
 
-    return new PrepositionPhrase(PrepositionPhraseRecord({
-        preposition: PrepositionFactory(prepositionOrPhrase),
-        object: NounPhraseFactory(object)
-    }));
+    return new PrepositionPhrase(
+        PrepositionPhraseRecord({
+            preposition: PrepositionFactory(config)(prepositionOrPhrase),
+            object: NounPhraseFactory(config)(object)
+        }),
+        config
+    );
 };
 
 export {

--- a/src/constituent/Pronoun.js
+++ b/src/constituent/Pronoun.js
@@ -26,12 +26,15 @@ class Pronoun extends Constituent {
 
 }
 
-const PronounFactory = (pronoun: Pronoun|string): Pronoun => {
+const PronounFactory = (config: Object) => (pronoun: Pronoun|string): Pronoun => {
     CheckType(pronoun, ["Pronoun", "string"]);
     if(Pronoun.isPronoun(pronoun)) {
         return pronoun;
     }
-    return new Pronoun(PronounRecord({pronoun}));
+    return new Pronoun(
+        PronounRecord({pronoun}),
+        config
+    );
 };
 
 export {

--- a/src/constituent/Sentence.js
+++ b/src/constituent/Sentence.js
@@ -40,10 +40,13 @@ class Sentence extends Constituent {
 
 }
 
-const SentenceFactory = (...sentence: Consitutent|string): Sentence => {
-    return new Sentence(SentenceRecord({
-        sentence: List(sentence).filter(ii => ii)
-    }));
+const SentenceFactory = (config: Object) => (...sentence: Consitutent|string): Sentence => {
+    return new Sentence(
+        SentenceRecord({
+            sentence: List(sentence).filter(ii => ii)
+        }),
+        config
+    );
 };
 
 export {

--- a/src/constituent/Series.js
+++ b/src/constituent/Series.js
@@ -5,7 +5,7 @@ import {CheckType} from '../decls/TypeErrors';
 
 const SeriesRecord = ConstituentRecordFactory({
     series: List(), // List<Constituent>
-    conjunction: ConjunctionFactory("and"),
+    conjunction: null,
     delimiter: ",",
     delimitLast: false
 });
@@ -54,7 +54,7 @@ class Series extends Constituent {
 
         const seriesList: List<Constituent> = List(series)
             .map(ii => typeof ii == "string"
-                ? ArbitraryStringFactory(ii)
+                ? ArbitraryStringFactory(this.config)(ii)
                 : ii
             );
 
@@ -71,7 +71,7 @@ class Series extends Constituent {
         CheckType(conjunction, ["Conjunction", "string", "null"]);
         return this.clone({
             data: this.data.set('conjunction', conjunction
-                ? ConjunctionFactory(conjunction)
+                ? ConjunctionFactory(this.config)(conjunction)
                 : null
             )
         });
@@ -113,7 +113,7 @@ class Series extends Constituent {
     }
 }
 
-const SeriesFactory = (series: Series|Array<Constituent>|List<Constituent>): Series => {
+const SeriesFactory = (config: Object) => (series: Series|Array<Constituent>|List<Constituent>): Series => {
     CheckType(series, ["Series", "Array", "List"]);
     if(Series.isSeries(series)) {
         return series;
@@ -121,13 +121,17 @@ const SeriesFactory = (series: Series|Array<Constituent>|List<Constituent>): Ser
 
     const seriesList: List<Constituent> = List(series)
         .map(ii => typeof ii == "string"
-            ? ArbitraryStringFactory(ii)
+            ? ArbitraryStringFactory(config)(ii)
             : ii
         );
 
-    const seriesInstance: Series = new Series(SeriesRecord({
-        series: seriesList
-    }));
+    const seriesInstance: Series = new Series(
+        SeriesRecord({
+            series: seriesList,
+            conjunction: ConjunctionFactory(config)("and")
+        }),
+        config
+    );
 
     return seriesInstance;
 };

--- a/src/constituent/Verb.js
+++ b/src/constituent/Verb.js
@@ -1,5 +1,6 @@
 import {Constituent, ConstituentRecordFactory} from './Constituent';
 import {CheckType, CheckEnum} from '../decls/TypeErrors';
+import {numberFromQuantity, NUMBER_ENUM, PERSON_ENUM} from './Noun';
 
 const TENSE_ENUM = [
     'past',
@@ -49,7 +50,7 @@ class Verb extends Constituent {
 
         return new Verb(
             data,
-            this.lexicon
+            this.config
         );
     }
 
@@ -62,7 +63,7 @@ class Verb extends Constituent {
             person
         } = this.data;
 
-        //console.log(this.lexicon);
+        //console.log(this.config);
 
         if(aspect == "continuous" || aspect == "perfectContinuous") {
             verb += "ing";
@@ -131,14 +132,69 @@ class Verb extends Constituent {
         return this.aspect('perfectContinuous');
     }
 
+    //
+    // number
+    //
+
+    number(number: string): NounPhrase {
+        CheckEnum(number, NUMBER_ENUM);
+        return this.clone({
+            data: this.data.set('number', number)
+        });
+    }
+
+    numberFromQuantity(quantity: number): NounPhrase {
+        return this.clone({
+            data: this.data.set('number', numberFromQuantity(quantity))
+        });
+    }
+
+    plural(): NounPhrase {
+        return this.number('plural');
+    }
+
+    singular(): NounPhrase {
+        return this.number('singular');
+    }
+
+    single(): NounPhrase {
+        return this.number('singular');
+    }
+
+    //
+    // person
+    //
+
+    person(person: string): NounPhrase {
+        CheckEnum(person, PERSON_ENUM);
+        return this.clone({
+            data: this.data.set('person', person)
+        });
+    }
+
+    firstPerson(): NounPhrase {
+        return this.person('first');
+    }
+
+    secondPerson(): NounPhrase {
+        return this.person('second');
+    }
+
+    thirdPerson(): NounPhrase {
+        return this.person('third');
+    }
+
 }
 
-const VerbFactory = (lexicon: Object) => (verb: Verb|string): Verb => {
+const VerbFactory = (config: Object) => (verb: Verb|string): Verb => {
     CheckType(verb, ["Verb", "string"]);
     if(verb instanceof Verb) {
         return verb;
     }
-    return new Verb(VerbRecord({verb}), lexicon);
+    return new Verb(
+        VerbRecord({verb}),
+        config
+    );
 };
 
 export {

--- a/src/constituent/VerbPhrase.js
+++ b/src/constituent/VerbPhrase.js
@@ -1,5 +1,5 @@
 import {List, Map} from 'immutable';
-import {Constituent, ConstituentRecordFactory} from './Constituent';
+import {Constituent, ConstituentRecordFactory, ArbitraryString} from './Constituent';
 import {Verb, VerbFactory} from './Verb';
 import {AdverbFactory} from './Adverb';
 import {CheckType, CheckEnum} from '../decls/TypeErrors';
@@ -93,7 +93,12 @@ class VerbPhrase extends Constituent {
         CheckType(position, ['string']);
         CheckEnum(position, ADVERB_POSITION_ENUM);
         return this.clone({
-            data: this.data.updateIn(['adverbs', position], advs => advs.push(AdverbFactory(adv)))
+            data: this.data.updateIn(
+                ['adverbs', position],
+                advs => advs.push(
+                    AdverbFactory(this.config)(adv)
+                )
+            )
         });
     }
 
@@ -102,7 +107,7 @@ class VerbPhrase extends Constituent {
     }
 }
 
-const VerbPhraseFactory = (
+const VerbPhraseFactory = (config: Object) => (
     verb: VerbPhrase|Verb|string,
     object: ?Clause|NounPhrase|AdjectivePhrase
 ): VerbPhrase => {
@@ -114,10 +119,15 @@ const VerbPhraseFactory = (
     CheckType(object, ['Clause', 'NounPhrase', 'AdjectivePhrase', 'null', 'undefined']);
     object = object || null;
 
-    return new VerbPhrase(VerbPhraseRecord({
-        verb: Series.isSeries(verb) ? verb : VerbFactory()(verb),
-        object
-    }));
+    return new VerbPhrase(
+        VerbPhraseRecord({
+            verb: Series.isSeries(verb) || ArbitraryString.isArbitraryString(verb)
+                ? verb
+                : VerbFactory(config)(verb),
+            object
+        }),
+        config
+    );
 };
 
 export {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
+import {Map} from 'immutable';
 import {AdjectiveFactory} from './constituent/Adjective';
 import {AdjectivePhraseFactory} from './constituent/AdjectivePhrase';
 import {AdverbFactory} from './constituent/Adverb';
 import {AdverbPhraseFactory} from './constituent/AdverbPhrase';
+import {ArbitraryStringFactory} from './constituent/Constituent';
 import {ClauseFactory} from './constituent/Clause';
 import {ConjunctionFactory} from './constituent/Conjunction';
 import {DeterminerFactory} from './constituent/Determiner';
@@ -16,13 +18,17 @@ import {SentenceFactory} from './constituent/Sentence';
 import {VerbFactory} from './constituent/Verb';
 import {VerbPhraseFactory} from './constituent/VerbPhrase';
 
+const defaultConfig = {
+    numberRenderer: ii => `${ii}`
+};
 
-function Constituent(lexicon: Object) {
-    return {
+function Constituent(config: Object) {
+    return Map({
         Adjective: AdjectiveFactory,
         AdjectivePhrase: AdjectivePhraseFactory,
         Adverb: AdverbFactory,
         AdverbPhrase: AdverbPhraseFactory,
+        ArbitraryString: ArbitraryStringFactory,
         Clause: ClauseFactory,
         Conjunction: ConjunctionFactory,
         Determiner: DeterminerFactory,
@@ -34,7 +40,7 @@ function Constituent(lexicon: Object) {
         Pronoun: PronounFactory,
         Sentence: SentenceFactory,
         Series: SeriesFactory,
-        Verb: VerbFactory(lexicon),
+        Verb: VerbFactory,
         VerbPhrase: VerbPhraseFactory,
 
         // short hand
@@ -50,9 +56,11 @@ function Constituent(lexicon: Object) {
         P: PrepositionFactory,
         PP: PrepositionPhraseFactory,
         Pro: PronounFactory,
-        V: VerbFactory(lexicon),
+        V: VerbFactory,
         VP: VerbPhraseFactory
-    };
+    })
+        .map(ii => ii({...defaultConfig, ...config}))
+        .toObject();
 }
 
 export {


### PR DESCRIPTION
- Pass config to all constituents
- Export Arbitrary string (can be used in place of Adv, Adj, Noun, Verb)
- Add configurable number formatter